### PR TITLE
Use ILIAS proxy for hub connection, if configured

### DIFF
--- a/src/Framework/Framework.php
+++ b/src/Framework/Framework.php
@@ -94,6 +94,14 @@ class Framework implements H5PFrameworkInterface {
 
 			$curlConnection->init();
 
+			// use a proxy, if configured by ILIAS
+			$proxy = \ilProxySettings::_getInstance();
+			if ($proxy->isActive()) {
+
+				$curlConnection->setOpt(CURLOPT_PROXY, $proxy->getHost());
+				$curlConnection->setOpt(CURLOPT_PROXYPORT, $proxy->getPort());
+			}
+
 			$curlConnection->setOpt(CURLOPT_RETURNTRANSFER, true);
 
 			$curlConnection->setOpt(CURLOPT_TIMEOUT, ($blocking) ? 30 : 0.1);


### PR DESCRIPTION
We had problems to reload  from the H5P hub with our installation behind the firewall. Using the configured proxy solved this.