### PR TITLE
Fixing 'Resresh HUB' typo and adding additional variable translations.

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2,9 +2,15 @@ obj_xhfp#:#H5P
 obj_xhfp_duplicate#:#H5P kopieren
 objs_xhfp#:#H5P's
 objs_xhfp_duplicate#:#H5P's kopieren
+grp_create_xhfp#:#H5P anlegen
+crs_create_xhfp#:#H5P anlegen
+cat_create_xhfp#:#H5P anlegen
+root_create_xhfp#:#H5P anlegen
+fold_create_xhfp#:#H5P anlegen
 rbac_create_xhfp#:#H5P anlegen
 rep_robj_xhfp_obj_xhfp#:#H5P
 xhfp_add#:#Hinzufügen
+xhfp_copy#:#H5P kopieren
 xhfp_delete#:#Löschen
 xhfp_edit_permission#:#Rechte bearbeiten
 xhfp_new#:#H5P anlegen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -2,9 +2,15 @@ obj_xhfp#:#H5P
 obj_xhfp_duplicate#:#Copy H5P
 objs_xhfp#:#H5P's
 objs_xhfp_duplicate#:#Copy H5P's
+grp_create_xhfp#:#Create H5P
+crs_create_xhfp#:#Create H5P
+cat_create_xhfp#:#Create H5P
+root_create_xhfp#:#Create H5P
+fold_create_xhfp#:#Create H5P
 rbac_create_xhfp#:#Create H5P
 rep_robj_xhfp_obj_xhfp#:#H5P
 xhfp_add#:#Add
+xhfp_copy#:#Copy
 xhfp_delete#:#Delete
 xhfp_edit_permission#:#Edit permission
 xhfp_new#:#Create H5P

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -66,7 +66,7 @@ finished#:#Finished
 fullscreen#:#Fullscreen
 hide_advanced#:#Hide advanced
 hub_last_refresh#:#HUB last refreshed: %s
-hub_refresh#:#Resresh HUB
+hub_refresh#:#Refresh HUB
 hub_refreshed#:#HUB was successfully refreshed
 import#:#Import
 import_content#:#Import content

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -2,9 +2,15 @@ obj_xhfp#:#H5P
 obj_xhfp_duplicate#:#Copy H5P
 objs_xhfp#:#H5P's
 objs_xhfp_duplicate#:#Copy H5P's
+grp_create_xhfp#:#Create H5P
+crs_create_xhfp#:#Create H5P
+cat_create_xhfp#:#Create H5P
+root_create_xhfp#:#Create H5P
+fold_create_xhfp#:#Create H5P
 rbac_create_xhfp#:#Create H5P
 rep_robj_xhfp_obj_xhfp#:#H5P
 xhfp_add#:#Add
+xhfp_copy#:#Copy
 xhfp_delete#:#Delete
 xhfp_edit_permission#:#Edit permission
 xhfp_new#:#Create H5P

--- a/lang/ilias_nl.lang
+++ b/lang/ilias_nl.lang
@@ -66,7 +66,7 @@ finished#:#Finished
 fullscreen#:#Fullscreen
 hide_advanced#:#Hide advanced
 hub_last_refresh#:#HUB last refreshed: %s
-hub_refresh#:#Resresh HUB
+hub_refresh#:#Refresh HUB
 hub_refreshed#:#HUB was successfully refreshed
 import#:#Import
 import_content#:#Import content


### PR DESCRIPTION
Noticed a small typo in the button, submitting the fix.

![Button screenshot](https://user-images.githubusercontent.com/7096681/126808344-f4889b61-424c-4680-954a-713208317987.png)

Also noticed missing translations for roles:

![Roles screenshot](https://user-images.githubusercontent.com/7096681/128773586-6bf86591-ca0e-426e-85fb-d19c38a26747.png)
