### PR TITLE
Copying dbupdates #14 and #15 to #19 and #20 so they are executed when upgrading from Ilias 7 to Ilias 8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # H5P Changelog
 
+## 5.0.17
+
+- Copying database updates that get missed upgrading from ilias 7 to ilias 8.
+
 ## 5.0.16
 
 - Fixed an issue where the H5PPageComponent plugin could not be used if this plugin has been deactivated.

--- a/plugin.php
+++ b/plugin.php
@@ -1,7 +1,7 @@
 <?php
 
 $id = "xhfp";
-$version = "5.0.16";
+$version = "5.0.17";
 $ilias_min_version = "8.0";
 $ilias_max_version  = "8.999";
 $responsible        = "sr solutions ag";

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -1339,3 +1339,26 @@ if ($ilDB->tableColumnExists('rep_robj_xhfp_solv', 'content_id')) {
     ]);
 }
 ?>
+<#19>
+<?php
+/**
+ * @var $ilDB ilDBInterface
+ */
+if ($ilDB->tableColumnExists('rep_robj_xhfp_lib_hub', 'mnachine_name')) {
+	$ilDB->dropTableColumn('rep_robj_xhfp_lib_hub', 'mnachine_name');
+}
+?>
+<#20>
+<?php
+global $DIC;
+
+// this setting will eventually be used in ILIAS\Filesystem\Security\Sanitizing\FilenameSanitizerImpl
+// to allow the suffix "h5p" for file names. This needs to be done for import/exports to work.
+$whitelist = $DIC->settings()->get('suffix_custom_white_list', '');
+$whitelist = explode(',', $whitelist);
+
+if (!in_array('h5p', $whitelist, true)) {
+	$whitelist[] = 'h5p';
+	$DIC->settings()->set('suffix_custom_white_list', implode(',', $whitelist));
+}
+?>


### PR DESCRIPTION
Here is the details of the bug that this fixes: (I did report the bug https://jira.sr.solutions/servicedesk/customer/portal/27/SUPPORT-14318)

> Hello,
> 
> We are upgrading our Ilias instance from 7.27 to 8.8. In that we are upgrading the H5P plugin from version 4.1.13, db_version 15 to 5.0.14, db_version 18.
> 
> We noticed that because the db_versions goes from 15 to 18, the updates #14 and #15 from the Ilias 8 version plugin (code https://github.com/srsolutionsag/H5P/blob/release_8/sql/dbupdate.php#L1137-L1159) are not applied.
> 
> The above causes the first error, where clicking the ‘Refresh libraries’ button fails and throws a database error (attached) because the column ‘mnachine_name’ is not removed from ‘rep_robj_xhfp_lib_hub’.
> 
> Secondly after that failure occurs, when we try to run the Ilias updates again we get this error: [ERROR] Undefined constant "ILIAS_WEB_DIR". I am not why it is related but it seems to be occurring after the failed error.
> 
> Let me know if you have any questions and what is a work around to still apply updates #14 and #15 when upgrading from Ilias 7 to 8.
> 
> Thank you
> Daniel